### PR TITLE
Feature/TR-5072/Add a percentage operator

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# http://editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 250

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+    # Keep npm dependencies up to date
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+      target-branch: 'develop'
+      allow:
+          - dependency-type: 'production'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -37,7 +37,7 @@ jobs:
               uses: slavcodev/coverage-monitor-action@1.1.0
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
-                  clover_file: .coverage/clover.xml
+                  clover_file: coverage/clover.xml
                   threshold_alert: 75
                   threshold_warning: 90
                   comment_mode: update

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,53 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Continuous integration
+
+on:
+    pull_request:
+        branches: [develop]
+
+jobs:
+    code-check:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  token: ${{ secrets.GH_TOKEN }}
+            - run: git fetch --tags --unshallow
+            - name: Check commit
+              if: always()
+              uses: oat-sa/conventional-commit-action@v0
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 14.x
+                  registry-url: https://registry.npmjs.org
+            - name: Install packages
+              run: npm ci
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.BUILD_NPM_TOKEN }}
+            - name: Running tests
+              run: |
+                  npm run coverage
+                  npm run coverage:clover
+            - name: Report coverage
+              if: always()
+              uses: slavcodev/coverage-monitor-action@1.1.0
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  clover_file: .coverage/clover.xml
+                  threshold_alert: 75
+                  threshold_warning: 90
+                  comment_mode: update
+            - name: Save Code Linting Report JSON
+              if: always()
+              run: npm run lint:report
+            - name: Annotate Code Linting Results
+              if: always()
+              continue-on-error: true
+              uses: ataylorme/eslint-annotate-action@1.2.0
+              with:
+                  repo-token: '${{ secrets.GITHUB_TOKEN }}'
+                  report-json: 'eslint_report.json'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
 coverage
+eslint_report.json
 .idea
 .nyc_output

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ export {
 };
 
 // Backwards compatibility
-export default{
+export default {
   Parser: Parser,
   Expression: Expression
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,9 +83,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.21.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.1.tgz",
-      "integrity": "sha512-JzhBFpkuhBNYUY7qs+wTzNmyCWUHEaAFpQQD2YfU1rPL38/L43Wvid0fFkiOCnHvsGncRZgEPyGnltABLcVDTg==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
+      "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
       "dev": true
     },
     "@babel/template": {
@@ -100,19 +100,19 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.0.tgz",
-      "integrity": "sha512-Xdt2P1H4LKTO8ApPfnO1KmzYMFpp7D/EinoXzLYN/cHcBNrVCAkAtGUcXnHXrl/VGktureU6fkQrHSBE2URfoA==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.2.tgz",
+      "integrity": "sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.0",
+        "@babel/generator": "^7.21.1",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.21.0",
-        "@babel/types": "^7.21.0",
+        "@babel/parser": "^7.21.2",
+        "@babel/types": "^7.21.2",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -126,9 +126,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.0.tgz",
-      "integrity": "sha512-uR7NWq2VNFnDi7EYqiRz2Jv/VQIu38tu64Zy8TX2nQFQ6etJ9V/Rr2msW8BS132mum2rL645qpDrLtAJtVpuow==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
+      "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -198,9 +198,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
-      "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
+      "version": "18.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.1.tgz",
+      "integrity": "sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==",
       "dev": true
     },
     "acorn": {
@@ -1744,6 +1744,34 @@
         "html-escaper": "^2.0.0"
       }
     },
+    "jest-worker": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1932,6 +1960,12 @@
           "dev": true
         }
       }
+    },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "dev": true
     },
     "merge-source-map": {
       "version": "1.1.0",
@@ -2157,6 +2191,23 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      }
     },
     "nyc": {
       "version": "14.1.1",
@@ -2508,6 +2559,12 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
+    "pidtree": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+      "dev": true
+    },
     "pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -2773,23 +2830,6 @@
         "terser": "^5.0.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jest-worker": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-          "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*",
-            "merge-stream": "^2.0.0",
-            "supports-color": "^7.0.0"
-          }
-        },
         "serialize-javascript": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
@@ -2797,15 +2837,6 @@
           "dev": true,
           "requires": {
             "randombytes": "^2.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
           }
         }
       }
@@ -2882,6 +2913,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true
+    },
+    "shell-quote": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.0.tgz",
+      "integrity": "sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==",
       "dev": true
     },
     "side-channel": {
@@ -3010,6 +3047,17 @@
         }
       }
     },
+    "string.prototype.padend": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.4.tgz",
+      "integrity": "sha512-67otBXoksdjsnXXRUq+KMVTdlVRZ2af422Y0aTyTjVaoQkGr3mxl2Bc5emi7dOQ3OGVVQQskmLEWwFXwommpNw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
     "string.prototype.trimend": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
@@ -3114,9 +3162,9 @@
       }
     },
     "terser": {
-      "version": "5.16.4",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.4.tgz",
-      "integrity": "sha512-5yEGuZ3DZradbogeYQ1NaGz7rXVBDWujWlx1PT8efXO6Txn+eWbfKqB2bTDVmFXmePFkoLU6XI8UektMIEA0ug==",
+      "version": "5.16.5",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.5.tgz",
+      "integrity": "sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "scripts": {
     "test": "npm run build && mocha",
     "coverage": "npm run build && nyc --reporter=lcov --reporter=text-summary mocha",
+    "coverage:clover": "nyc report -r clover",
     "lint": "eslint index.js src test rollup.config.js rollup-min.config.js",
+    "lint:report": "eslint index.js src test rollup.config.js rollup-min.config.js --output-file eslint_report.json --format json",
     "watch": "rollup -c rollup.config.js -w",
     "build": "rollup -c rollup.config.js && rollup -c rollup-min.config.js && rollup -c rollup-esm.config.js",
     "prepublish": "npm run build"

--- a/package.json
+++ b/package.json
@@ -18,12 +18,15 @@
     "eslint-plugin-promise": "^4.3.1",
     "eslint-plugin-standard": "^4.1.0",
     "mocha": "^10.0.0",
+    "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
     "rollup": "^1.20.3",
     "rollup-plugin-terser": "^7.0.2"
   },
   "scripts": {
     "test": "npm run build && mocha",
+    "test:watch": "mocha -w",
+    "dev": "run-p watch test:watch",
     "coverage": "npm run build && nyc --reporter=lcov --reporter=text-summary mocha",
     "coverage:clover": "nyc report -r clover",
     "lint": "eslint index.js src test rollup.config.js rollup-min.config.js",

--- a/rollup-min.config.js
+++ b/rollup-min.config.js
@@ -1,7 +1,7 @@
 import rollupConfig from './rollup.config';
 import { terser } from 'rollup-plugin-terser';
 
-rollupConfig.plugins = [ terser() ];
+rollupConfig.plugins = [terser()];
 rollupConfig.output.file = 'dist/bundle.min.js';
 
 export default rollupConfig;

--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -63,9 +63,10 @@ export default function evaluate(tokens, expr, values) {
     } else if (type === IFUNCOP) {
       n2 = nstack.pop();
       n1 = nstack.pop();
+      args = [n1, n2];
       f = expr.functions[item.value];
       if (f.apply && f.call) {
-        nstack.push(f.apply(undefined, [n1, n2]));
+        nstack.push(f.apply(undefined, args));
       } else {
         throw new Error(f + ' is not a function');
       }

--- a/src/expression-to-string.js
+++ b/src/expression-to-string.js
@@ -66,11 +66,15 @@ export default function expressionToString(tokens, toJS) {
           nstack.push('(' + '!' + n1 + ')');
         } else if (f === '!') {
           nstack.push('fac(' + n1 + ')');
+        } else if (f === '#') {
+          nstack.push('percent(' + n1 + ')');
         } else {
           nstack.push(f + '(' + n1 + ')');
         }
       } else if (f === '!') {
         nstack.push('(' + n1 + '!)');
+      } else if (f === '#') {
+        nstack.push('(' + n1 + '#)');
       } else {
         nstack.push('(' + f + ' ' + n1 + ')');
       }

--- a/src/expression-to-string.js
+++ b/src/expression-to-string.js
@@ -119,9 +119,9 @@ export default function expressionToString(tokens, toJS) {
   }
   if (nstack.length > 1) {
     if (toJS) {
-      nstack = [ nstack.join(',') ];
+      nstack = [nstack.join(',')];
     } else {
-      nstack = [ nstack.join(';') ];
+      nstack = [nstack.join(';')];
     }
   }
   return String(nstack[0]);

--- a/src/functions.js
+++ b/src/functions.js
@@ -330,7 +330,7 @@ export function sign(x) {
   return ((x > 0) - (x < 0)) || +x;
 }
 
-var ONE_THIRD = 1/3;
+var ONE_THIRD = 1 / 3;
 export function cbrt(x) {
   return x < 0 ? -Math.pow(-x, ONE_THIRD) : Math.pow(x, ONE_THIRD);
 }

--- a/src/functions.js
+++ b/src/functions.js
@@ -114,6 +114,10 @@ export function factorial(a) { // a!
   return gamma(a + 1);
 }
 
+export function percent(a) { // a%
+  return a / 100;
+}
+
 function isInteger(value) {
   return isFinite(value) && (value === Math.round(value));
 }

--- a/src/parser-state.js
+++ b/src/parser-state.js
@@ -263,10 +263,13 @@ ParserState.prototype.parseExponential = function (instr) {
   }
 };
 
+var POSTFIX_OPERATORS = ['!', '#'];
+
 ParserState.prototype.parsePostfixExpression = function (instr) {
   this.parseFunctionOperator(instr);
-  while (this.accept(TOP, '!')) {
-    instr.push(unaryInstruction('!'));
+  while (this.accept(TOP, POSTFIX_OPERATORS)) {
+    var op = this.current;
+    instr.push(unaryInstruction(op.value));
   }
 };
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -88,6 +88,7 @@ export function Parser(options) {
     not: not,
     length: stringOrArrayLength,
     '!': factorial,
+    '#': percent,
     sign: Math.sign || sign
   };
 
@@ -181,6 +182,7 @@ var optionNameMap = {
   '%': 'remainder',
   '^': 'power',
   '!': 'factorial',
+  '#': 'percent',
   '<': 'comparison',
   '>': 'comparison',
   '<=': 'comparison',

--- a/src/parser.js
+++ b/src/parser.js
@@ -30,6 +30,7 @@ import {
   trunc,
   random,
   factorial,
+  percent,
   gamma,
   stringOrArrayLength,
   hypot,
@@ -118,6 +119,7 @@ export function Parser(options) {
   this.functions = {
     random: random,
     fac: factorial,
+    percent: percent,
     min: min,
     max: max,
     hypot: Math.hypot || hypot,

--- a/src/parser.js
+++ b/src/parser.js
@@ -108,7 +108,7 @@ export function Parser(options) {
     '<=': lessThanEqual,
     and: andOperator,
     or: orOperator,
-    'in': inOperator,
+    in: inOperator,
     '=': setVar,
     '[': arrayIndex
   };
@@ -127,7 +127,7 @@ export function Parser(options) {
     pyt: Math.hypot || hypot, // backward compat
     pow: Math.pow,
     atan2: Math.atan2,
-    'if': condition,
+    if: condition,
     gamma: gamma,
     roundTo: roundTo,
     map: arrayMap,
@@ -141,8 +141,8 @@ export function Parser(options) {
   this.consts = {
     E: Math.E,
     PI: Math.PI,
-    'true': true,
-    'false': false
+    true: true,
+    false: false
   };
 }
 
@@ -190,9 +190,9 @@ var optionNameMap = {
   '==': 'comparison',
   '!=': 'comparison',
   '||': 'concatenate',
-  'and': 'logical',
-  'or': 'logical',
-  'not': 'logical',
+  and: 'logical',
+  or: 'logical',
+  not: 'logical',
   '?': 'conditional',
   ':': 'conditional',
   '=': 'assignment',
@@ -201,7 +201,7 @@ var optionNameMap = {
 };
 
 function getOptionName(op) {
-  return optionNameMap.hasOwnProperty(op) ? optionNameMap[op] : op;
+  return Object.prototype.hasOwnProperty.call(optionNameMap, op) ? optionNameMap[op] : op;
 }
 
 Parser.prototype.isOperatorEnabled = function (op) {

--- a/src/simplify.js
+++ b/src/simplify.js
@@ -16,7 +16,7 @@ export default function simplify(tokens, unaryOps, binaryOps, ternaryOps, values
       } else {
         nstack.push(item);
       }
-    } else if (type === IVAR && values.hasOwnProperty(item.value)) {
+    } else if (type === IVAR && Object.prototype.hasOwnProperty.call(values, item.value)) {
       item = new Instruction(INUMBER, values[item.value]);
       nstack.push(item);
     } else if (type === IOP2 && nstack.length > 1) {
@@ -49,13 +49,7 @@ export default function simplify(tokens, unaryOps, binaryOps, ternaryOps, values
     } else if (type === IMEMBER && nstack.length > 0) {
       n1 = nstack.pop();
       nstack.push(new Instruction(INUMBER, n1.value[item.value]));
-    } /* else if (type === IARRAY && nstack.length >= item.value) {
-      var length = item.value;
-      while (length-- > 0) {
-        newexpression.push(nstack.pop());
-      }
-      newexpression.push(new Instruction(IARRAY, item.value));
-    } */ else {
+    } else {
       while (nstack.length > 0) {
         newexpression.push(nstack.shift());
       }

--- a/src/token-stream.js
+++ b/src/token-stream.js
@@ -404,7 +404,7 @@ TokenStream.prototype.isOperator = function () {
   var startPos = this.pos;
   var c = this.expression.charAt(this.pos);
 
-  if (c === '+' || c === '-' || c === '*' || c === '/' || c === '%' || c === '^' || c === '?' || c === ':' || c === '.') {
+  if (c === '+' || c === '-' || c === '*' || c === '/' || c === '%' || c === '^' || c === '?' || c === ':' || c === '.' || c === '#') {
     this.current = this.newToken(TOP, c);
   } else if (c === '∙' || c === '•') {
     this.current = this.newToken(TOP, '*');

--- a/test/expression.js
+++ b/test/expression.js
@@ -96,7 +96,7 @@ describe('Expression', function () {
     });
 
     it('[1, 2] || [3, 4] || [5, 6]', function () {
-      assert.deepStrictEqual(Parser.evaluate('[1, 2] || [3, 4] || [5, 6]'), [ 1, 2, 3, 4, 5, 6 ]);
+      assert.deepStrictEqual(Parser.evaluate('[1, 2] || [3, 4] || [5, 6]'), [1, 2, 3, 4, 5, 6]);
     });
 
     it('should fail with undefined variables', function () {
@@ -351,11 +351,11 @@ describe('Expression', function () {
     });
 
     it('a[2] + b[3]', function () {
-      assert.strictEqual(Parser.parse('a[2] + b[3]').simplify({ a: [ 0, 0, 5, 0 ], b: [ 0, 0, 0, 4, 0 ] }).toString(), '9');
-      assert.strictEqual(Parser.parse('a[2] + b[3]').simplify({ a: [ 0, 0, 5, 0 ] }).toString(), '(5 + b[3])');
-      assert.strictEqual(Parser.parse('a[2] + b[5 - 2]').simplify({ b: [ 0, 0, 0, 4, 0 ] }).toString(), '(a[2] + 4)');
-      assert.strictEqual(Parser.parse('a[two] + b[3]').simplify({ a: [ 0, 0, 5, 0 ], b: [ 0, 0, 0, 4, 0 ] }).toString(), '([0, 0, 5, 0][two] + 4)');
-      assert.strictEqual(Parser.parse('a[two] + b[3]').simplify({ a: [ 0, 'New\nLine', 5, 0 ], b: [ 0, 0, 0, 4, 0 ] }).toString(), '([0, "New\\nLine", 5, 0][two] + 4)');
+      assert.strictEqual(Parser.parse('a[2] + b[3]').simplify({ a: [0, 0, 5, 0], b: [0, 0, 0, 4, 0] }).toString(), '9');
+      assert.strictEqual(Parser.parse('a[2] + b[3]').simplify({ a: [0, 0, 5, 0] }).toString(), '(5 + b[3])');
+      assert.strictEqual(Parser.parse('a[2] + b[5 - 2]').simplify({ b: [0, 0, 0, 4, 0] }).toString(), '(a[2] + 4)');
+      assert.strictEqual(Parser.parse('a[two] + b[3]').simplify({ a: [0, 0, 5, 0], b: [0, 0, 0, 4, 0] }).toString(), '([0, 0, 5, 0][two] + 4)');
+      assert.strictEqual(Parser.parse('a[two] + b[3]').simplify({ a: [0, 'New\nLine', 5, 0], b: [0, 0, 0, 4, 0] }).toString(), '([0, "New\\nLine", 5, 0][two] + 4)');
     });
   });
 
@@ -703,7 +703,7 @@ describe('Expression', function () {
     it('[4, 3] || [1, 2]', function () {
       var expr = parser.parse('x || y');
       var f = expr.toJSFunction('x, y');
-      assert.deepStrictEqual(f([ 4, 3 ], [ 1, 2 ]), [ 4, 3, 1, 2 ]);
+      assert.deepStrictEqual(f([4, 3], [1, 2]), [4, 3, 1, 2]);
     });
 
     it('x = x + 1', function () {
@@ -927,17 +927,17 @@ describe('Expression', function () {
     });
 
     it('a[2]', function () {
-      assert.strictEqual(parser.parse('a[2]').toJSFunction('a')([ 1, 2, 3 ]), 3);
+      assert.strictEqual(parser.parse('a[2]').toJSFunction('a')([1, 2, 3]), 3);
     });
 
     it('a[2.9]', function () {
-      assert.strictEqual(parser.parse('a[2.9]').toJSFunction('a')([ 1, 2, 3, 4, 5 ]), 3);
+      assert.strictEqual(parser.parse('a[2.9]').toJSFunction('a')([1, 2, 3, 4, 5]), 3);
     });
 
     it('a[n]', function () {
-      assert.strictEqual(parser.parse('a[n]').toJSFunction('a,n')([ 1, 2, 3 ], 0), 1);
-      assert.strictEqual(parser.parse('a[n]').toJSFunction('a,n')([ 1, 2, 3 ], 1), 2);
-      assert.strictEqual(parser.parse('a[n]').toJSFunction('a,n')([ 1, 2, 3 ], 2), 3);
+      assert.strictEqual(parser.parse('a[n]').toJSFunction('a,n')([1, 2, 3], 0), 1);
+      assert.strictEqual(parser.parse('a[n]').toJSFunction('a,n')([1, 2, 3], 1), 2);
+      assert.strictEqual(parser.parse('a[n]').toJSFunction('a,n')([1, 2, 3], 2), 3);
     });
 
     it('a["foo"]', function () {

--- a/test/expression.js
+++ b/test/expression.js
@@ -666,6 +666,10 @@ describe('Expression', function () {
       assert.strictEqual(parser.parse('(x - 1)!').toString(), '((x - 1)!)');
     });
 
+    it('(x - 1)#', function () {
+      assert.strictEqual(parser.parse('(x - 1)#').toString(), '((x - 1)#)');
+    });
+
     it('a[0]', function () {
       assert.strictEqual(parser.parse('a[0]').toString(), 'a[0]');
     });
@@ -897,6 +901,15 @@ describe('Expression', function () {
       assert.strictEqual(parser.parse('(x - 1)!').toJSFunction('x')(4), 6);
       assert.strictEqual(parser.parse('(x - 1)!').toJSFunction('x')(5), 24);
       assert.strictEqual(parser.parse('(x - 1)!').toJSFunction('x')(6), 120);
+    });
+
+    it('(x - 1)#', function () {
+      assert.strictEqual(parser.parse('(x - 1)#').toJSFunction('x')(1), 0);
+      assert.strictEqual(parser.parse('(x - 1)#').toJSFunction('x')(2), 0.01);
+      assert.strictEqual(parser.parse('(x - 1)#').toJSFunction('x')(3), 0.02);
+      assert.strictEqual(parser.parse('(x - 1)#').toJSFunction('x')(10), 0.09);
+      assert.strictEqual(parser.parse('(x - 1)#').toJSFunction('x')(11), 0.1);
+      assert.strictEqual(parser.parse('(x - 1)#').toJSFunction('x')(100), 0.99);
     });
 
     it('(f(x) = g(y) = x * y)(a)(b)', function () {

--- a/test/functions.js
+++ b/test/functions.js
@@ -102,6 +102,23 @@ describe('Functions', function () {
     });
   });
 
+  describe('percent(n)', function () {
+    it('should return n%', function () {
+      var parser = new Parser();
+      assert.strictEqual(parser.evaluate('percent(0)'), 0);
+      assert.strictEqual(parser.evaluate('percent(1)'), 0.01);
+      assert.strictEqual(parser.evaluate('percent(2)'), 0.02);
+      assert.strictEqual(parser.evaluate('percent(2.5)'), 0.025);
+      assert.strictEqual(parser.evaluate('percent(10)'), 0.1);
+      assert.strictEqual(parser.evaluate('percent(42)'), 0.42);
+      assert.strictEqual(parser.evaluate('percent(55.55)'), 0.5555);
+      assert.strictEqual(parser.evaluate('percent(99)'), 0.99);
+      assert.strictEqual(parser.evaluate('percent(100)'), 1);
+      assert.strictEqual(parser.evaluate('percent(120)'), 1.2);
+      assert.strictEqual(parser.evaluate('percent(210)'), 2.1);
+    });
+  });
+
   describe('min(a, b, ...)', function () {
     it('should return the smallest value', function () {
       var parser = new Parser();

--- a/test/functions.js
+++ b/test/functions.js
@@ -284,20 +284,20 @@ describe('Functions', function () {
 
     it('should call built-in functions', function () {
       var parser = new Parser();
-      assert.deepStrictEqual(parser.evaluate('map(sqrt, [0, 1, 16, 81])'), [ 0, 1, 4, 9 ]);
-      assert.deepStrictEqual(parser.evaluate('map(max, [2, 2, 2, 2, 2, 2])'), [ 2, 2, 2, 3, 4, 5 ]);
+      assert.deepStrictEqual(parser.evaluate('map(sqrt, [0, 1, 16, 81])'), [0, 1, 4, 9]);
+      assert.deepStrictEqual(parser.evaluate('map(max, [2, 2, 2, 2, 2, 2])'), [2, 2, 2, 3, 4, 5]);
     });
 
     it('should call self-defined functions', function () {
       var parser = new Parser();
-      assert.deepStrictEqual(parser.evaluate('f(a) = a*a; map(f, [0, 1, 2, 3, 4])'), [ 0, 1, 4, 9, 16 ]);
+      assert.deepStrictEqual(parser.evaluate('f(a) = a*a; map(f, [0, 1, 2, 3, 4])'), [0, 1, 4, 9, 16]);
     });
 
     it('should call self-defined functions with index', function () {
       var parser = new Parser();
-      assert.deepStrictEqual(parser.evaluate('f(a, i) = a+i; map(f, [1,3,5,7,9])'), [ 1, 4, 7, 10, 13 ]);
-      assert.deepStrictEqual(parser.evaluate('map(anon(a, i) = a+i, [1,3,5,7,9])'), [ 1, 4, 7, 10, 13 ]);
-      assert.deepStrictEqual(parser.evaluate('f(a, i) = i; map(f, [1,3,5,7,9])'), [ 0, 1, 2, 3, 4 ]);
+      assert.deepStrictEqual(parser.evaluate('f(a, i) = a+i; map(f, [1,3,5,7,9])'), [1, 4, 7, 10, 13]);
+      assert.deepStrictEqual(parser.evaluate('map(anon(a, i) = a+i, [1,3,5,7,9])'), [1, 4, 7, 10, 13]);
+      assert.deepStrictEqual(parser.evaluate('f(a, i) = i; map(f, [1,3,5,7,9])'), [0, 1, 2, 3, 4]);
     });
   });
 
@@ -360,19 +360,19 @@ describe('Functions', function () {
 
     it('should call built-in functions', function () {
       var parser = new Parser();
-      assert.deepStrictEqual(parser.evaluate('filter(not, [1, 0, false, true, 2, ""])'), [ 0, false, '' ]);
+      assert.deepStrictEqual(parser.evaluate('filter(not, [1, 0, false, true, 2, ""])'), [0, false, '']);
     });
 
     it('should call self-defined functions', function () {
       var parser = new Parser();
-      assert.deepStrictEqual(parser.evaluate('f(x) = x > 2; filter(f, [1, 2, 0, 3, -1, 4])'), [ 3, 4 ]);
+      assert.deepStrictEqual(parser.evaluate('f(x) = x > 2; filter(f, [1, 2, 0, 3, -1, 4])'), [3, 4]);
       assert.deepStrictEqual(parser.evaluate('f(x) = x > 2; filter(f, [1, 2, 0, 1.9, -1, -4])'), []);
     });
 
     it('should call self-defined functions with index', function () {
       var parser = new Parser();
-      assert.deepStrictEqual(parser.evaluate('f(a, i) = a <= i; filter(f, [1,0,5,3,2])'), [ 0, 3, 2 ]);
-      assert.deepStrictEqual(parser.evaluate('f(a, i) = i > 3; filter(f, [9,0,5,6,1,2,3,4])'), [ 1, 2, 3, 4 ]);
+      assert.deepStrictEqual(parser.evaluate('f(a, i) = a <= i; filter(f, [1,0,5,3,2])'), [0, 3, 2]);
+      assert.deepStrictEqual(parser.evaluate('f(a, i) = i > 3; filter(f, [9,0,5,6,1,2,3,4])'), [1, 2, 3, 4]);
     });
   });
 

--- a/test/operators.js
+++ b/test/operators.js
@@ -221,27 +221,27 @@ describe('Operators', function () {
     var parser = new Parser();
 
     it('"a" in ["a", "b"]', function () {
-      assert.strictEqual(parser.evaluate('"a" in toto', { 'toto': ['a', 'b'] }), true);
+      assert.strictEqual(parser.evaluate('"a" in toto', { toto: ['a', 'b'] }), true);
     });
 
     it('"a" in ["b", "a"]', function () {
-      assert.strictEqual(parser.evaluate('"a" in toto', { 'toto': ['b', 'a'] }), true);
+      assert.strictEqual(parser.evaluate('"a" in toto', { toto: ['b', 'a'] }), true);
     });
 
     it('3 in [4, 3]', function () {
-      assert.strictEqual(parser.evaluate('3 in toto', { 'toto': [4, 3] }), true);
+      assert.strictEqual(parser.evaluate('3 in toto', { toto: [4, 3] }), true);
     });
 
     it('"c" in ["a", "b"]', function () {
-      assert.strictEqual(parser.evaluate('"c" in toto', { 'toto': ['a', 'b'] }), false);
+      assert.strictEqual(parser.evaluate('"c" in toto', { toto: ['a', 'b'] }), false);
     });
 
     it('"c" in ["b", "a"]', function () {
-      assert.strictEqual(parser.evaluate('"c" in toto', { 'toto': ['b', 'a'] }), false);
+      assert.strictEqual(parser.evaluate('"c" in toto', { toto: ['b', 'a'] }), false);
     });
 
     it('3 in [1, 2]', function () {
-      assert.strictEqual(parser.evaluate('3 in toto', { 'toto': [1, 2] }), false);
+      assert.strictEqual(parser.evaluate('3 in toto', { toto: [1, 2] }), false);
     });
   });
 
@@ -910,19 +910,19 @@ describe('Operators', function () {
 
   describe('[] operator', function () {
     it('a[0]', function () {
-      assert.strictEqual(Parser.evaluate('a[0]', { a: [ 4, 3, 2, 1 ] }), 4);
+      assert.strictEqual(Parser.evaluate('a[0]', { a: [4, 3, 2, 1] }), 4);
     });
 
     it('a[0.1]', function () {
-      assert.strictEqual(Parser.evaluate('a[0.1]', { a: [ 4, 3, 2, 1 ] }), 4);
+      assert.strictEqual(Parser.evaluate('a[0.1]', { a: [4, 3, 2, 1] }), 4);
     });
 
     it('a[3]', function () {
-      assert.strictEqual(Parser.evaluate('a[3]', { a: [ 4, 3, 2, 1 ] }), 1);
+      assert.strictEqual(Parser.evaluate('a[3]', { a: [4, 3, 2, 1] }), 1);
     });
 
     it('a[3 - 2]', function () {
-      assert.strictEqual(Parser.evaluate('a[3 - 2]', { a: [ 4, 3, 2, 1 ] }), 3);
+      assert.strictEqual(Parser.evaluate('a[3 - 2]', { a: [4, 3, 2, 1] }), 3);
     });
 
     it('a["foo"]', function () {
@@ -930,7 +930,7 @@ describe('Operators', function () {
     });
 
     it('a[2]^3', function () {
-      assert.strictEqual(Parser.evaluate('a[2]^3', { a: [ 1, 2, 3, 4 ] }), 27);
+      assert.strictEqual(Parser.evaluate('a[2]^3', { a: [1, 2, 3, 4] }), 27);
     });
   });
 
@@ -959,9 +959,9 @@ describe('Operators', function () {
       assert.ok(isNaN(parser.evaluate('cbrt(0/0)')));
       assert.strictEqual(parser.evaluate('cbrt -1'), -1);
       assert.strictEqual(parser.evaluate('cbrt 0'), 0);
-      assert.strictEqual(parser.evaluate('cbrt(-1/0)'), -1/0);
+      assert.strictEqual(parser.evaluate('cbrt(-1/0)'), -1 / 0);
       assert.strictEqual(parser.evaluate('cbrt 1'), 1);
-      assert.strictEqual(parser.evaluate('cbrt(1/0)'), 1/0);
+      assert.strictEqual(parser.evaluate('cbrt(1/0)'), 1 / 0);
       assertCloseTo(parser.evaluate('cbrt 2'), 1.2599210498948732, delta);
       assertCloseTo(parser.evaluate('cbrt -2'), -1.2599210498948732, delta);
       assert.strictEqual(parser.evaluate('cbrt 8'), 2);
@@ -997,7 +997,7 @@ describe('Operators', function () {
       var delta = 1e-15;
 
       assert.ok(isNaN(parser.evaluate('log1p(0/0)')));
-      assert.strictEqual(parser.evaluate('log1p -1'), -1/0);
+      assert.strictEqual(parser.evaluate('log1p -1'), -1 / 0);
       assert.strictEqual(parser.evaluate('log1p 0'), 0);
       assertCloseTo(parser.evaluate('log1p 1'), 0.6931471805599453, delta);
       assert.ok(isNaN(parser.evaluate('log1p -2')));
@@ -1014,7 +1014,7 @@ describe('Operators', function () {
 
       assert.ok(isNaN(parser.evaluate('log2(0/0)')));
       assert.ok(isNaN(parser.evaluate('log2 -1')));
-      assert.strictEqual(parser.evaluate('log2 0'), -1/0);
+      assert.strictEqual(parser.evaluate('log2 0'), -1 / 0);
       assert.strictEqual(Parser.evaluate('log2 1'), 0);
       assert.strictEqual(Parser.evaluate('log2 2'), 1);
       assert.strictEqual(Parser.evaluate('log2 3'), 1.584962500721156);

--- a/test/operators.js
+++ b/test/operators.js
@@ -1026,4 +1026,40 @@ describe('Operators', function () {
       assertCloseTo(parser.parse('log2 x').toJSFunction('x')(3), 1.584962500721156, delta);
     });
   });
+
+  describe('x#', function () {
+    it('has the correct precedence', function () {
+      assert.strictEqual(parser.parse('2^3#').toString(), '(2 ^ (3#))');
+      assert.strictEqual(parser.parse('-5#').toString(), '(-(5#))');
+      assert.strictEqual(parser.parse('4#^3').toString(), '((4#) ^ 3)');
+      assert.strictEqual(parser.parse('sqrt(4)#').toString(), '((sqrt 4)#)');
+      assert.strictEqual(parser.parse('sqrt 4#').toString(), '(sqrt (4#))');
+      assert.strictEqual(parser.parse('x##').toString(), '((x#)#)');
+    });
+
+    it('returns percentage as a fraction', function () {
+      assert.strictEqual(parser.evaluate('(-10)#'), -0.1);
+      assert.strictEqual(parser.evaluate('(-2)#'), -0.02);
+      assert.strictEqual(parser.evaluate('(-1)#'), -0.01);
+      assert.strictEqual(parser.evaluate('0#'), 0);
+      assert.strictEqual(parser.evaluate('1#'), 0.01);
+      assert.strictEqual(parser.evaluate('2#'), 0.02);
+      assert.strictEqual(parser.evaluate('3#'), 0.03);
+      assert.strictEqual(parser.evaluate('3.65#'), 0.0365);
+      assert.strictEqual(parser.evaluate('4#'), 0.04);
+      assert.strictEqual(parser.evaluate('5#'), 0.05);
+      assert.strictEqual(parser.evaluate('10#'), 0.1);
+      assert.strictEqual(parser.evaluate('20#'), 0.2);
+      assert.strictEqual(parser.evaluate('30#'), 0.3);
+      assert.strictEqual(parser.evaluate('55.55#'), 0.5555);
+      assert.strictEqual(parser.evaluate('90#'), 0.9);
+      assert.strictEqual(parser.evaluate('99#'), 0.99);
+      assert.strictEqual(parser.evaluate('100#'), 1);
+      assert.strictEqual(parser.evaluate('125#'), 1.25);
+      assert.strictEqual(parser.evaluate('150#'), 1.5);
+      assert.strictEqual(parser.evaluate('170#'), 1.7);
+      assert.strictEqual(parser.evaluate('171#'), 1.71);
+      assert.strictEqual(parser.evaluate('200#'), 2);
+    });
+  });
 });

--- a/test/parser.js
+++ b/test/parser.js
@@ -235,7 +235,7 @@ describe('Parser', function () {
         assert.strictEqual(parser.parse('sin;').toString(), '(sin)');
         assert.strictEqual(parser.parse('(sin)').toString(), 'sin');
         assert.strictEqual(parser.parse('sin; (2)^3').toString(), '(sin;(2 ^ 3))');
-        assert.deepStrictEqual(parser.parse('f(sin, sqrt)').evaluate({ f: function (a, b) { return [ a, b ]; }}), [ Math.sin, Math.sqrt ]);
+        assert.deepStrictEqual(parser.parse('f(sin, sqrt)').evaluate({ f: function (a, b) { return [a, b]; } }), [Math.sin, Math.sqrt]);
         assert.strictEqual(parser.parse('sin').evaluate(), Math.sin);
         assert.strictEqual(parser.parse('cos;').evaluate(), Math.cos);
         assert.strictEqual(parser.parse('cos;tan').evaluate(), Math.tan);
@@ -260,31 +260,31 @@ describe('Parser', function () {
       });
 
       it('should parse valid variable names correctly', function () {
-        assert.deepStrictEqual(parser.parse('a').variables(), [ 'a' ]);
-        assert.deepStrictEqual(parser.parse('abc').variables(), [ 'abc' ]);
-        assert.deepStrictEqual(parser.parse('a+b').variables(), [ 'a', 'b' ]);
-        assert.deepStrictEqual(parser.parse('ab+c').variables(), [ 'ab', 'c' ]);
-        assert.deepStrictEqual(parser.parse('a1').variables(), [ 'a1' ]);
-        assert.deepStrictEqual(parser.parse('a_1').variables(), [ 'a_1' ]);
-        assert.deepStrictEqual(parser.parse('a_').variables(), [ 'a_' ]);
-        assert.deepStrictEqual(parser.parse('a_c').variables(), [ 'a_c' ]);
-        assert.deepStrictEqual(parser.parse('A').variables(), [ 'A' ]);
-        assert.deepStrictEqual(parser.parse('ABC').variables(), [ 'ABC' ]);
-        assert.deepStrictEqual(parser.parse('A+B').variables(), [ 'A', 'B' ]);
-        assert.deepStrictEqual(parser.parse('AB+C').variables(), [ 'AB', 'C' ]);
-        assert.deepStrictEqual(parser.parse('A1').variables(), [ 'A1' ]);
-        assert.deepStrictEqual(parser.parse('A_1').variables(), [ 'A_1' ]);
-        assert.deepStrictEqual(parser.parse('A_C').variables(), [ 'A_C' ]);
-        assert.deepStrictEqual(parser.parse('abcdefg/hijklmnop+qrstuvwxyz').variables(), [ 'abcdefg', 'hijklmnop', 'qrstuvwxyz' ]);
-        assert.deepStrictEqual(parser.parse('ABCDEFG/HIJKLMNOP+QRSTUVWXYZ').variables(), [ 'ABCDEFG', 'HIJKLMNOP', 'QRSTUVWXYZ' ]);
-        assert.deepStrictEqual(parser.parse('abc123+def456*ghi789/jkl0').variables(), [ 'abc123', 'def456', 'ghi789', 'jkl0' ]);
-        assert.deepStrictEqual(parser.parse('_').variables(), [ '_' ]);
-        assert.deepStrictEqual(parser.parse('_x').variables(), [ '_x' ]);
-        assert.deepStrictEqual(parser.parse('$x').variables(), [ '$x' ]);
-        assert.deepStrictEqual(parser.parse('$xyz').variables(), [ '$xyz' ]);
-        assert.deepStrictEqual(parser.parse('$a_sdf').variables(), [ '$a_sdf' ]);
-        assert.deepStrictEqual(parser.parse('$xyz_123').variables(), [ '$xyz_123' ]);
-        assert.deepStrictEqual(parser.parse('_xyz_123').variables(), [ '_xyz_123' ]);
+        assert.deepStrictEqual(parser.parse('a').variables(), ['a']);
+        assert.deepStrictEqual(parser.parse('abc').variables(), ['abc']);
+        assert.deepStrictEqual(parser.parse('a+b').variables(), ['a', 'b']);
+        assert.deepStrictEqual(parser.parse('ab+c').variables(), ['ab', 'c']);
+        assert.deepStrictEqual(parser.parse('a1').variables(), ['a1']);
+        assert.deepStrictEqual(parser.parse('a_1').variables(), ['a_1']);
+        assert.deepStrictEqual(parser.parse('a_').variables(), ['a_']);
+        assert.deepStrictEqual(parser.parse('a_c').variables(), ['a_c']);
+        assert.deepStrictEqual(parser.parse('A').variables(), ['A']);
+        assert.deepStrictEqual(parser.parse('ABC').variables(), ['ABC']);
+        assert.deepStrictEqual(parser.parse('A+B').variables(), ['A', 'B']);
+        assert.deepStrictEqual(parser.parse('AB+C').variables(), ['AB', 'C']);
+        assert.deepStrictEqual(parser.parse('A1').variables(), ['A1']);
+        assert.deepStrictEqual(parser.parse('A_1').variables(), ['A_1']);
+        assert.deepStrictEqual(parser.parse('A_C').variables(), ['A_C']);
+        assert.deepStrictEqual(parser.parse('abcdefg/hijklmnop+qrstuvwxyz').variables(), ['abcdefg', 'hijklmnop', 'qrstuvwxyz']);
+        assert.deepStrictEqual(parser.parse('ABCDEFG/HIJKLMNOP+QRSTUVWXYZ').variables(), ['ABCDEFG', 'HIJKLMNOP', 'QRSTUVWXYZ']);
+        assert.deepStrictEqual(parser.parse('abc123+def456*ghi789/jkl0').variables(), ['abc123', 'def456', 'ghi789', 'jkl0']);
+        assert.deepStrictEqual(parser.parse('_').variables(), ['_']);
+        assert.deepStrictEqual(parser.parse('_x').variables(), ['_x']);
+        assert.deepStrictEqual(parser.parse('$x').variables(), ['$x']);
+        assert.deepStrictEqual(parser.parse('$xyz').variables(), ['$xyz']);
+        assert.deepStrictEqual(parser.parse('$a_sdf').variables(), ['$a_sdf']);
+        assert.deepStrictEqual(parser.parse('$xyz_123').variables(), ['$xyz_123']);
+        assert.deepStrictEqual(parser.parse('_xyz_123').variables(), ['_xyz_123']);
       });
 
       it('should not parse invalid variables', function () {
@@ -355,7 +355,7 @@ describe('Parser', function () {
             sqrt: true,
             divide: true,
             percent: true,
-            'in': true,
+            in: true,
             assignment: true
           }
         });
@@ -363,7 +363,7 @@ describe('Parser', function () {
         assert.strictEqual(parser.evaluate('sqrt(16)'), 4);
         assert.strictEqual(parser.evaluate('50#'), 0.5);
         assert.strictEqual(parser.evaluate('4 / 6'), 2 / 3);
-        assert.strictEqual(parser.evaluate('3 in array', { array: [ 1, 2, 3 ] }), true);
+        assert.strictEqual(parser.evaluate('3 in array', { array: [1, 2, 3] }), true);
         assert.strictEqual(parser.evaluate('x = 4', { x: 2 }), 4);
       });
     });
@@ -446,23 +446,23 @@ describe('Parser', function () {
     it('should allow in operator to be enabled', function () {
       var parser = new Parser({
         operators: {
-          'in': true
+          in: true
         }
       });
 
       assert.throws(function () { parser.parse('5 * in'); }, Error);
-      assert.strictEqual(parser.evaluate('5 in a', { a: [ 2, 3, 5 ] }), true);
+      assert.strictEqual(parser.evaluate('5 in a', { a: [2, 3, 5] }), true);
     });
 
     it('should allow in operator to be disabled', function () {
       var parser = new Parser({
         operators: {
-          'in': false
+          in: false
         }
       });
 
       assert.throws(function () { parser.parse('5 in a'); }, Error);
-      assert.strictEqual(parser.evaluate('5 * in', { 'in': 3 }), 15);
+      assert.strictEqual(parser.evaluate('5 * in', { in: 3 }), 15);
     });
 
     it('should allow logical operators to be disabled', function () {
@@ -522,7 +522,7 @@ describe('Parser', function () {
     it('should allow assignment operator to be enabled', function () {
       var parser = new Parser({
         operators: {
-          'assignment': true
+          assignment: true
         }
       });
 
@@ -533,7 +533,7 @@ describe('Parser', function () {
     it('should allow assignment operator to be disabled', function () {
       var parser = new Parser({
         operators: {
-          'assignment': false
+          assignment: false
         }
       });
 
@@ -554,7 +554,7 @@ describe('Parser', function () {
       });
 
       assert.deepStrictEqual(parser.evaluate('[1, 2, 3]'), [1, 2, 3]);
-      assert.strictEqual(parser.evaluate('a[0]', { a: [ 4, 2 ] }), 4);
+      assert.strictEqual(parser.evaluate('a[0]', { a: [4, 2] }), 4);
     });
 
     it('should allow arrays to be disabled', function () {

--- a/test/parser.js
+++ b/test/parser.js
@@ -165,6 +165,7 @@ describe('Parser', function () {
         assert.throws(function () { parser.parse('"a" | "b"'); }, Error);
         assert.throws(function () { parser.parse('2 = 2'); }, Error);
         assert.throws(function () { parser.parse('2 ! 3'); }, Error);
+        assert.throws(function () { parser.parse('2 # 3'); }, Error);
         assert.throws(function () { parser.parse('1 o 0'); }, Error);
         assert.throws(function () { parser.parse('1 an 2'); }, Error);
         assert.throws(function () { parser.parse('1 a 2'); }, Error);
@@ -333,11 +334,13 @@ describe('Parser', function () {
           operators: {
             add: false,
             sin: false,
+            percent: false,
             remainder: false,
             divide: false
           }
         });
         assert.throws(function () { parser.parse('+1'); }, /\+/);
+        assert.throws(function () { parser.parse('10#'); }, /#/);
         assert.throws(function () { parser.parse('1 + 2'); }, /\+/);
         assert.strictEqual(parser.parse('sin(0)').toString(), 'sin(0)');
         assert.throws(function () { parser.evaluate('sin(0)'); }, /sin/);
@@ -351,12 +354,14 @@ describe('Parser', function () {
             add: true,
             sqrt: true,
             divide: true,
+            percent: true,
             'in': true,
             assignment: true
           }
         });
         assert.strictEqual(parser.evaluate('+(-1)'), -1);
         assert.strictEqual(parser.evaluate('sqrt(16)'), 4);
+        assert.strictEqual(parser.evaluate('50#'), 0.5);
         assert.strictEqual(parser.evaluate('4 / 6'), 2 / 3);
         assert.strictEqual(parser.evaluate('3 in array', { array: [ 1, 2, 3 ] }), true);
         assert.strictEqual(parser.evaluate('x = 4', { x: 2 }), 4);
@@ -426,6 +431,16 @@ describe('Parser', function () {
       });
 
       assert.throws(function () { parser.parse('5!'); }, /!/);
+    });
+
+    it('should allow percent operator to be disabled', function () {
+      var parser = new Parser({
+        operators: {
+          percent: false
+        }
+      });
+
+      assert.throws(function () { parser.parse('5#'); }, /#/);
     });
 
     it('should allow in operator to be enabled', function () {

--- a/test/parser.js
+++ b/test/parser.js
@@ -253,6 +253,20 @@ describe('Parser', function () {
         assert.strictEqual(parser.parse('4 • 5').toString(), '(4 * 5)');
       });
 
+      it('should evaluate percentage operator', function () {
+        assert.strictEqual(parser.evaluate('50#'), 0.5);
+        assert.strictEqual(parser.evaluate('50*10#'), 5);
+        assert.strictEqual(parser.evaluate('50/10#'), 500);
+        assert.strictEqual(parser.evaluate('50+10#'), 55);
+        assert.strictEqual(parser.evaluate('50-10#'), 45);
+        assert.strictEqual(parser.evaluate('10#+50'), 50.1);
+        assert.strictEqual(parser.evaluate('10#-50'), -49.9);
+        assert.strictEqual(parser.evaluate('10#*50'), 5);
+        assert.strictEqual(parser.evaluate('10#/50'), 0.002);
+        assert.strictEqual(parser.evaluate('50+(3*4)#'), 56);
+        assert.strictEqual(parser.evaluate('50-(3*4)#'), 44);
+      });
+
       it('should parse variables that start with operators', function () {
         assert.strictEqual(parser.parse('org > 5').toString(), '(org > 5)');
         assert.strictEqual(parser.parse('android * 2').toString(), '(android * 2)');


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/TR-5072

### Summary

Adds a percentage operator for turning the postfixed value into a percentage.

Also, add GitHub workflow for checking code style and unit tests.

### Details

In order to offer support for percentage values, a `percent` function and a related operator have been added.
Since the symbol `%` was already taken for the remainder (modulo), the percent operator has been set to `#`.

For extracting a percentage value: `10#` relates to 10% and it will be converted to `0.1`.

The operator also takes care of the context. Out of context, it only applies the formula `N / 100`. This is fine when the percentage is applied as a product (A * B%). For context-based percentage (A + B%), the expression needs to be transformed prior to evaluating it.

Here is the formula mapping:
- `A%` is computed as `A / 100`
- `A * B%` is computed as `A * (B / 100)`
- `A / B%` is computed as `A / (B / 100)`
- `A + B%` is processed as `A + (A * B%)`, which will be computed as `A + (A * (B / 100))`
- `A - B%` is processed as `A - (A * B%)`, which will be computed as `A - (A * (B / 100))`

Due to the operator’s precedence, the following will apply:
- `A + B% * C` will be processed as `A + ((B / 100) * C)`
- `A + B * C%` will be processed as `A + (B * (C / 100))`
- `(A + B%) * C` will be processed as `(A + (A * (B / 100))) * C`

Commands for reporting code coverage and linting have been added too: `npm coverage:clover` and `npm run lint:report`.
In order to automate the unit testing and the linter, configuration for GitHub actions has been added. Some code style issues have also been fixed so that the first report will be clean.

To ease the review:
- function added with the commit https://github.com/oat-sa/expr-eval/pull/10/commits/490d1841d4a7f9e751d0576e9e566f3a03fa76ec
- operator added with the commit https://github.com/oat-sa/expr-eval/pull/10/commits/38b4fe5b1cc05a2a80bc0b4be1ef1e06109f3de6
- reporting commands added with the commit https://github.com/oat-sa/expr-eval/pull/10/commits/d1220c5190486e1dec43976952d48a033a9df74c
- finally, the operator is made context-aware with the commit https://github.com/oat-sa/expr-eval/pull/10/commits/dfabe521347289566fb7bcd1cd70a52e933940c8

### How to test

- run the unit tests: `npm test`
- run the linter: `npm run lint`