### PR TITLE
Fix/TR-5072/Correct precedence for compound percentage operator

### DIFF
--- a/src/parser-state.js
+++ b/src/parser-state.js
@@ -211,7 +211,7 @@ ParserState.prototype.parseAddSub = function (instr) {
   this.parseTerm(instr);
   while (this.accept(TOP, ADD_SUB_OPERATORS)) {
     var op = this.current;
-    this.parseTerm(instr);
+    this.parseAddSub(instr);
     instr.push(binaryInstruction(op.value));
   }
 };

--- a/test/expression.js
+++ b/test/expression.js
@@ -634,7 +634,7 @@ describe('Expression', function () {
 
     it('2+(x=3;y=4;z=x*y)+5', function () {
       var parser = new Parser();
-      assert.strictEqual(parser.parse('2+(x=3;y=4;z=x*y)+5').toString(), '((2 + ((x = (3));((y = (4));(z = ((x * y)))))) + 5)');
+      assert.strictEqual(parser.parse('2+(x=3;y=4;z=x*y)+5').toString(), '(2 + (((x = (3));((y = (4));(z = ((x * y))))) + 5))');
     });
 
     it('[1, 2, 3]', function () {
@@ -646,7 +646,7 @@ describe('Expression', function () {
     });
 
     it('["a", ["b", ["c"]], true, 1 + 2 + 3]', function () {
-      assert.strictEqual(Parser.parse('["a", ["b", ["c"]], true, 1 + 2 + 3]').toString(), '["a", ["b", ["c"]], true, ((1 + 2) + 3)]');
+      assert.strictEqual(Parser.parse('["a", ["b", ["c"]], true, 1 + 2 + 3]').toString(), '["a", ["b", ["c"]], true, (1 + (2 + 3))]');
     });
 
     it('\'as\' || \'df\'', function () {

--- a/test/parser.js
+++ b/test/parser.js
@@ -258,7 +258,9 @@ describe('Parser', function () {
         assert.strictEqual(parser.evaluate('50*10#'), 5);
         assert.strictEqual(parser.evaluate('50/10#'), 500);
         assert.strictEqual(parser.evaluate('50+10#'), 55);
+        assert.strictEqual(parser.evaluate('10+20+10#'), 32);
         assert.strictEqual(parser.evaluate('50-10#'), 45);
+        assert.strictEqual(parser.evaluate('10-20-10#'), -8);
         assert.strictEqual(parser.evaluate('10#+50'), 50.1);
         assert.strictEqual(parser.evaluate('10#-50'), -49.9);
         assert.strictEqual(parser.evaluate('10#*50'), 5);


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/TR-5072

### Summary

Correct a stupid issue with compound percentage operation as the precedence for the right-hand operand was lower while it should be higher.

### Details

When computing the expression `10+20+10%`, the parsing tree was generating left-to-right:
```
     +
   /   \
  +     %
 / \   /
10 20 10
```

While it should rather turn into a right-to-left recursion for sums in order to apply the percentage to the right closest operand:
```
    +
   / \
  10  +
     / \
    20  %
       /
      10
```

### How to test
- run the unit tests: `npm test`