### PR TITLE
Fix/TR-5072/Correct the sum commutativity

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,12 @@
+{
+    "trailingComma": "none",
+    "tabWidth": 2,
+    "tab": false,
+    "printWidth": 250,
+    "semi": true,
+    "singleQuote": true,
+    "quoteProps": "as-needed",
+    "bracketSpacing": true,
+    "arrowParens": "avoid",
+    "endOfLine": "lf"
+  }

--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ f(), x.y, a[i]           | Left          | Function call, property access, array
 ^                        | Right         | Exponentiation
 +, -, not, sqrt, etc.    | Right         | Unary prefix operators (see below for the full list)
 \*, /, %                 | Left          | Multiplication, division, remainder
-+, -, \|\|               | Left          | Addition, subtraction, array/list concatenation
+\|\|                     | Left          | array/list concatenation
++, -                     | Left (Right)  | Addition, subtraction (associativity: `1+2+3` => `1+(2+3)`, `1-2-3` => `1+((-2)+(-3))`)
 ==, !=, >=, <=, >, <, in | Left          | Equals, not equals, etc. "in" means "is the left operand included in the right array operand?"
 and                      | Left          | Logical AND
 or                       | Left          | Logical OR
@@ -261,6 +262,7 @@ Operator | Description
 -x       | Negation
 +x       | Unary plus. This converts it's operand to a number, but has no other effect.
 x!       | Factorial (x * (x-1) * (x-2) * … * 2 * 1). gamma(x + 1) for non-integers.
+x#       | Percentage (`10% = 0.1`, `50 + 10% = 55`, `50 * 10% = 5`)
 abs x    | Absolute value (magnitude) of x
 acos x   | Arc cosine of x (in radians)
 acosh x  | Hyperbolic arc cosine of x (in radians)
@@ -301,6 +303,7 @@ Function      | Description
 :------------ | :----------
 random(n)     | Get a random number in the range [0, n). If n is zero, or not provided, it defaults to 1.
 fac(n)        | n! (factorial of n: "n * (n-1) * (n-2) * … * 2 * 1") Deprecated. Use the ! operator instead.
+percent(n)    | Turns a percentage into a value (`percent(10) = 0.1`).
 min(a,b,…)    | Get the smallest (minimum) number in the list.
 max(a,b,…)    | Get the largest (maximum) number in the list.
 hypot(a,b)    | Hypotenuse, i.e. the square root of the sum of squares of its arguments.
@@ -331,6 +334,16 @@ Examples:
     add(a, b) = a + b
     factorial(x) = x < 2 ? 1 : x * factorial(x - 1)
 ```
+
+#### Functions as binary operator
+
+You can turn any function that accepts 2 operands into a binary operator. To do so, you need to prefix the function name by `@` and do not add the parenthesis. The precedence is higher than the normal function call.
+
+Examples:
+
+    // equivalent to nthrt(4, 254)
+    4 @nthrt 254
+
 #### Custom JavaScript functions
 
 If you need additional functions that aren't supported out of the box, you can easily add them in your own code. Instances of the `Parser` class have a property called `functions` that's simply an object with all the functions that are in scope. You can add, replace, or delete any of the properties to customize what's available in the expressions. For example:

--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -3,6 +3,7 @@ import { INUMBER, IOP1, IOP2, IOP3, IVAR, IFUNCOP, IVARNAME, IFUNCALL, IFUNDEF, 
 export default function evaluate(tokens, expr, values) {
   var nstack = stackFactory();
   var n1, n2, n3;
+  var op1, op2;
   var f, args, argCount;
 
   if (isExpressionEvaluator(tokens)) {
@@ -14,82 +15,83 @@ export default function evaluate(tokens, expr, values) {
   for (var i = 0; i < numTokens; i++) {
     var item = tokens[i];
     var type = item.type;
+    var token = item.value;
     if (type === INUMBER || type === IVARNAME) {
-      nstack.push(item.value, item.value);
+      nstack.push(type, token);
     } else if (type === IOP2) {
-      var right = nstack.pop();
-      var left = nstack.pop();
-      n2 = right.value;
-      n1 = left.value;
-      if (item.value === 'and') {
-        nstack.push(item.value, n1 ? !!evaluate(n2, expr, values) : false);
-      } else if (item.value === 'or') {
-        nstack.push(item.value, n1 ? true : !!evaluate(n2, expr, values));
-      } else if (item.value === '=') {
-        f = expr.binaryOps[item.value];
-        nstack.push(item.value, f(n1, evaluate(n2, expr, values), values));
-      } else if ((item.value === '+' || item.value === '-') && right.token === '#' && right.token !== left.token) {
-        f = expr.binaryOps[item.value];
+      op2 = nstack.pop();
+      op1 = nstack.pop();
+      n2 = op2.value;
+      n1 = op1.value;
+      if (token === 'and') {
+        nstack.push(token, n1 ? !!evaluate(n2, expr, values) : false);
+      } else if (token === 'or') {
+        nstack.push(token, n1 ? true : !!evaluate(n2, expr, values));
+      } else if (token === '=') {
+        f = expr.binaryOps[token];
+        nstack.push(token, f(n1, evaluate(n2, expr, values), values));
+      } else if ((token === '+' || token === '-') && op2.token === '#' && op2.token !== op1.token) {
+        f = expr.binaryOps[token];
         n1 = resolveExpression(n1, values);
         n2 = evaluate([
           { type: INUMBER, value: n1 },
           { type: INUMBER, value: resolveExpression(n2, values) },
           { type: IOP2, value: '*' }
         ], expr, values);
-        nstack.push(item.value, f(n1, n2));
+        nstack.push(token, f(n1, n2));
       } else {
-        f = expr.binaryOps[item.value];
-        nstack.push(item.value, f(resolveExpression(n1, values), resolveExpression(n2, values)));
+        f = expr.binaryOps[token];
+        nstack.push(token, f(resolveExpression(n1, values), resolveExpression(n2, values)));
       }
     } else if (type === IOP3) {
       n3 = nstack.popValue();
       n2 = nstack.popValue();
       n1 = nstack.popValue();
-      if (item.value === '?') {
-        nstack.push(item.value, evaluate(n1 ? n2 : n3, expr, values));
+      if (token === '?') {
+        nstack.push(token, evaluate(n1 ? n2 : n3, expr, values));
       } else {
-        f = expr.ternaryOps[item.value];
-        nstack.push(item.value, f(resolveExpression(n1, values), resolveExpression(n2, values), resolveExpression(n3, values)));
+        f = expr.ternaryOps[token];
+        nstack.push(token, f(resolveExpression(n1, values), resolveExpression(n2, values), resolveExpression(n3, values)));
       }
     } else if (type === IVAR) {
-      if (/^__proto__|prototype|constructor$/.test(item.value)) {
+      if (/^__proto__|prototype|constructor$/.test(token)) {
         throw new Error('prototype access detected');
       }
-      if (item.value in expr.functions) {
-        nstack.push(item.value, expr.functions[item.value]);
-      } else if (item.value in expr.unaryOps && expr.parser.isOperatorEnabled(item.value)) {
-        nstack.push(item.value, expr.unaryOps[item.value]);
+      if (token in expr.functions) {
+        nstack.push(token, expr.functions[token]);
+      } else if (token in expr.unaryOps && expr.parser.isOperatorEnabled(token)) {
+        nstack.push(token, expr.unaryOps[token]);
       } else {
-        var v = values[item.value];
+        var v = values[token];
         if (v !== undefined) {
-          nstack.push(item.value, v);
+          nstack.push(token, v);
         } else {
-          throw new Error('undefined variable: ' + item.value);
+          throw new Error('undefined variable: ' + token);
         }
       }
     } else if (type === IOP1) {
       n1 = nstack.popValue();
-      f = expr.unaryOps[item.value];
-      nstack.push(item.value, f(resolveExpression(n1, values)));
+      f = expr.unaryOps[token];
+      nstack.push(token, f(resolveExpression(n1, values)));
     } else if (type === IFUNCOP) {
       n2 = nstack.popValue();
       n1 = nstack.popValue();
       args = [n1, n2];
-      f = expr.functions[item.value];
+      f = expr.functions[token];
       if (f.apply && f.call) {
-        nstack.push(item.value, f.apply(undefined, args));
+        nstack.push(token, f.apply(undefined, args));
       } else {
         throw new Error(f + ' is not a function');
       }
     } else if (type === IFUNCALL) {
-      argCount = item.value;
+      argCount = token;
       args = [];
       while (argCount-- > 0) {
         args.unshift(resolveExpression(nstack.popValue(), values));
       }
       f = nstack.popValue();
       if (f.apply && f.call) {
-        nstack.push(item.value, f.apply(undefined, args));
+        nstack.push(token, f.apply(undefined, args));
       } else {
         throw new Error(f + ' is not a function');
       }
@@ -98,7 +100,7 @@ export default function evaluate(tokens, expr, values) {
       nstack.push(type, (function () {
         var n2 = nstack.popValue();
         var args = [];
-        var argCount = item.value;
+        var argCount = token;
         while (argCount-- > 0) {
           args.unshift(nstack.popValue());
         }
@@ -119,21 +121,21 @@ export default function evaluate(tokens, expr, values) {
         return f;
       })());
     } else if (type === IEXPR) {
-      nstack.push(IEXPR, createExpressionEvaluator(item, expr, values));
+      nstack.push(type, createExpressionEvaluator(item, expr, values));
     } else if (type === IEXPREVAL) {
-      nstack.push(IEXPREVAL, item);
+      nstack.push(type, item);
     } else if (type === IMEMBER) {
       n1 = nstack.popValue();
-      nstack.push(item.value, n1[item.value]);
+      nstack.push(token, n1[token]);
     } else if (type === IENDSTATEMENT) {
       nstack.pop();
     } else if (type === IARRAY) {
-      argCount = item.value;
+      argCount = token;
       args = [];
       while (argCount-- > 0) {
         args.unshift(nstack.popValue());
       }
-      nstack.push(IARRAY, args);
+      nstack.push(type, args);
     } else {
       throw new Error('invalid Expression');
     }

--- a/src/parser-state.js
+++ b/src/parser-state.js
@@ -209,8 +209,17 @@ var ADD_SUB_OPERATORS = ['+', '-', '||'];
 
 ParserState.prototype.parseAddSub = function (instr) {
   this.parseTerm(instr);
+  this.save();
   while (this.accept(TOP, ADD_SUB_OPERATORS)) {
     var op = this.current;
+    if (op.value === '-') {
+      // Turns the subtraction into an addition of a negative number.
+      // This is needed as the addition is commutative while subtraction is not.
+      // To properly manage the percentage operator, the operation order is reversed,
+      // and the operation actually needs to be commutative.
+      op = Object.assign({}, op, { value: '+' });
+      this.restore();
+    }
     this.parseAddSub(instr);
     instr.push(binaryInstruction(op.value));
   }

--- a/src/parser-state.js
+++ b/src/parser-state.js
@@ -197,15 +197,23 @@ ParserState.prototype.parseAndExpression = function (instr) {
 var COMPARISON_OPERATORS = ['==', '!=', '<', '<=', '>=', '>', 'in'];
 
 ParserState.prototype.parseComparison = function (instr) {
-  this.parseAddSub(instr);
+  this.parseConcat(instr);
   while (this.accept(TOP, COMPARISON_OPERATORS)) {
     var op = this.current;
-    this.parseAddSub(instr);
+    this.parseConcat(instr);
     instr.push(binaryInstruction(op.value));
   }
 };
 
-var ADD_SUB_OPERATORS = ['+', '-', '||'];
+ParserState.prototype.parseConcat = function (instr) {
+  this.parseAddSub(instr);
+  while (this.accept(TOP, '||')) {
+    this.parseAddSub(instr);
+    instr.push(binaryInstruction('||'));
+  }
+};
+
+var ADD_SUB_OPERATORS = ['+', '-'];
 
 ParserState.prototype.parseAddSub = function (instr) {
   this.parseTerm(instr);

--- a/test/expression.js
+++ b/test/expression.js
@@ -79,6 +79,90 @@ describe('Expression', function () {
       assert.strictEqual(Parser.evaluate('10+ +1'), 11);
     });
 
+    it('10-1', function () {
+      assert.strictEqual(Parser.evaluate('10-1'), 9);
+    });
+
+    it('1+2+3', function () {
+      assert.strictEqual(Parser.evaluate('1+2+3'), 6);
+    });
+
+    it('-1-2-3', function () {
+      assert.strictEqual(Parser.evaluate('-1-2-3'), -6);
+    });
+
+    it('1+2-3+4-5', function () {
+      assert.strictEqual(Parser.evaluate('1+2-3+4-5'), -1);
+    });
+
+    it('3+4*5', function () {
+      assert.strictEqual(Parser.evaluate('3+4*5'), 23);
+    });
+
+    it('3*4+5', function () {
+      assert.strictEqual(Parser.evaluate('3*4+5'), 17);
+    });
+
+    it('3-4*5', function () {
+      assert.strictEqual(Parser.evaluate('3-4*5'), -17);
+    });
+
+    it('3*4-5', function () {
+      assert.strictEqual(Parser.evaluate('3*4-5'), 7);
+    });
+
+    it('(3+4)*5', function () {
+      assert.strictEqual(Parser.evaluate('(3+4)*5'), 35);
+    });
+
+    it('3*(4+5)', function () {
+      assert.strictEqual(Parser.evaluate('3*(4+5)'), 27);
+    });
+
+    it('(3-4)*5', function () {
+      assert.strictEqual(Parser.evaluate('(3-4)*5'), -5);
+    });
+
+    it('3*(4-5)', function () {
+      assert.strictEqual(Parser.evaluate('3*(4-5)'), -3);
+    });
+
+    it('50+10#', function () {
+      assert.strictEqual(Parser.evaluate('50+10#'), 55);
+    });
+
+    it('50-10#', function () {
+      assert.strictEqual(Parser.evaluate('50-10#'), 45);
+    });
+
+    it('50+(5*2)#', function () {
+      assert.strictEqual(Parser.evaluate('50+(5*2)#'), 55);
+    });
+
+    it('50-(5*2)#', function () {
+      assert.strictEqual(Parser.evaluate('50-(5*2)#'), 45);
+    });
+
+    it('50*10#', function () {
+      assert.strictEqual(Parser.evaluate('50*10#'), 5);
+    });
+
+    it('50/10#', function () {
+      assert.strictEqual(Parser.evaluate('50/10#'), 500);
+    });
+
+    it('10+20+10#', function () {
+      assert.strictEqual(Parser.evaluate('10+20+10#'), 32);
+    });
+
+    it('10+20-10#', function () {
+      assert.strictEqual(Parser.evaluate('10+20-10#'), 28);
+    });
+
+    it('10-20-10#', function () {
+      assert.strictEqual(Parser.evaluate('10-20-10#'), -8);
+    });
+
     it('10/-2', function () {
       assert.strictEqual(Parser.evaluate('10/-2'), -5);
     });
@@ -535,11 +619,11 @@ describe('Expression', function () {
     });
 
     it('2-3^x', function () {
-      assert.strictEqual(parser.parse('2-3^x').toString(), '(2 - (3 ^ x))');
+      assert.strictEqual(parser.parse('2-3^x').toString(), '(2 + (-(3 ^ x)))');
     });
 
     it('-2-3^x', function () {
-      assert.strictEqual(parser.parse('-2-3^x').toString(), '((-2) - (3 ^ x))');
+      assert.strictEqual(parser.parse('-2-3^x').toString(), '((-2) + (-(3 ^ x)))');
     });
 
     it('-3^x', function () {
@@ -663,11 +747,11 @@ describe('Expression', function () {
     });
 
     it('(x - 1)!', function () {
-      assert.strictEqual(parser.parse('(x - 1)!').toString(), '((x - 1)!)');
+      assert.strictEqual(parser.parse('(x - 1)!').toString(), '((x + (-1))!)');
     });
 
     it('(x - 1)#', function () {
-      assert.strictEqual(parser.parse('(x - 1)#').toString(), '((x - 1)#)');
+      assert.strictEqual(parser.parse('(x - 1)#').toString(), '((x + (-1))#)');
     });
 
     it('a[0]', function () {

--- a/test/expression.js
+++ b/test/expression.js
@@ -175,6 +175,10 @@ describe('Expression', function () {
       assert.strictEqual(Parser.evaluate('2^(-4)'), 1 / 16);
     });
 
+    it('10-6 || sqrt(4)', function () {
+      assert.strictEqual(Parser.evaluate('10-6 || sqrt(4)'), '42');
+    });
+
     it('\'as\' || \'df\'', function () {
       assert.strictEqual(Parser.evaluate('\'as\' || \'df\''), 'asdf');
     });


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/TR-5072

### Summary

In order to correct the percentage operator, a previous PR changed the parsing order of sums from left-to-right to right-to-left. Unfortunately, this was without considering that only the addition is commutative.

In other words, `1+2+3` was processed as `1+(2+3)`, which is still the same, and `1-2-3` was processed as `1-(2-3)`, which is not the same.

The idea behind this PR is to restore a proper evaluation of sums without losing the previous fix. To do so, any subtraction is converted into the addition of a negative number. This way only additions are processed in a sum, and each operation is commutative.

Now a sum like `1-2-3` is processed as `1 + -2 + -3` so that the order doesn't matter.

### Details

Several changes have been applied:
- https://github.com/oat-sa/expr-eval/commit/ffd057b17b7dc7faeab0833b9b1c1f6f4b5b3e99 - Several test cases have been added for proving the fix
- https://github.com/oat-sa/expr-eval/commit/be5cb9bc124fdc08cfe0093c12f05244479a81c9 - Subtractions are converted into the addition of a negative number
- https://github.com/oat-sa/expr-eval/commit/f942fa611952ec1ea5113525907cfc7fc7a8a2b8 - As the percentage depends on the context, it needs to be forwarded through the negation so that the addition can still detect it

Besides that, a few refactorings occurred to improve the consistency.

### How to test

- run the tests: `npm test`